### PR TITLE
relaxes the tf-svc-check dupe check

### DIFF
--- a/src/api/createV2/helpers/add-repo-name.js
+++ b/src/api/createV2/helpers/add-repo-name.js
@@ -46,17 +46,18 @@ function addRepoName({
     throw new Error('File failed schema validation')
   }
 
-  if (parsedRepositories[0][repositoryName] !== undefined) {
-    logger.error(
-      `Tenant Services file '${filePath}' from '${fileRepository} already contains an entry for ${repositoryName}`
+  // This guard probably isn't needed, but on the off-chance we get here, dont overwrite
+  // existing entries in the tenant_services.json file.
+  if (parsedRepositories[0][repositoryName] === undefined) {
+    parsedRepositories[0][repositoryName] = {
+      zone,
+      mongo: zone === 'protected',
+      redis: zone === 'public'
+    }
+  } else {
+    logger.warn(
+      `There's already and entry for '${repositoryName} in cdp-tf-svc-infra! We wont overwrite it.`
     )
-    throw new Error('Repository already exists')
-  }
-
-  parsedRepositories[0][repositoryName] = {
-    zone,
-    mongo: zone === 'protected',
-    redis: zone === 'public'
   }
 
   const postAdditionValidationResult = repositoriesSchema.validate(


### PR DESCRIPTION
given we have multiple checks in-front of this, the extra failure path seems excessive, better off warning and just not destructively updating.