### PR TITLE
Bump debug port

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "TZ=UTC jest --coverage --verbose",
     "test:watch": "TZ=UTC jest --watch",
     "server:watch": "nodemon --exec babel-node ./src",
-    "server:debug": "nodemon --exec babel-node --inspect ./src",
+    "server:debug": "nodemon --exec babel-node --inspect=9239 ./src",
     "prestart": "npm run build",
     "start": "NODE_ENV=production node --use-strict ./.server",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"


### PR DESCRIPTION
Bump the debug port so debug can be ran at the same time when using the Node.js suite of portal apps
- PFE - default debug port of `9229`
- SSOP's - `9239`
- USB - `9249` https://github.com/DEFRA/cdp-user-service-backend/pull/97

You will need to update your debugger ports accordingly 
