### PR TITLE
Don't transform ESM module in jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,13 @@ export default {
     '<rootDir>/src/__fixtures__',
     '<rootDir>/src/server/common/test-helpers'
   ],
-  coverageDirectory: '<rootDir>/coverage'
+  coverageDirectory: '<rootDir>/coverage',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  },
+
+  // @octokit/graphql is ESM only, ignore related ESM imports
+  transformIgnorePatterns: ['/node_modules(?!/(@octokit|universal-user-agent))']
 }
 /**
  * @import { Config } from 'jest'


### PR DESCRIPTION
Octokit/graphql is ESM module dont transfrom associated imports in jest tests