### PR TITLE
411709: Add in progress filters endpoint

### DIFF
--- a/src/api/status/controllers/in-progress-filters.js
+++ b/src/api/status/controllers/in-progress-filters.js
@@ -1,0 +1,25 @@
+import Joi from 'joi'
+
+import { statuses } from '~/src/constants/statuses.js'
+import { getStatusFilters } from '~/src/api/status/helpers/get-status-filters.js'
+
+const inProgressFiltersController = {
+  options: {
+    validate: {
+      query: Joi.object({
+        kind: Joi.string().allow('')
+      })
+    }
+  },
+  handler: async (request, h) => {
+    const filters = await getStatusFilters(
+      request.db,
+      [statuses.inProgress, statuses.failure],
+      request.query
+    )
+
+    return h.response({ message: 'success', filters })
+  }
+}
+
+export { inProgressFiltersController }

--- a/src/api/status/controllers/in-progress.js
+++ b/src/api/status/controllers/in-progress.js
@@ -1,13 +1,24 @@
+import Joi from 'joi'
+
 import { statuses } from '~/src/constants/statuses.js'
 import { getStatus } from '~/src/api/status/helpers/get-status.js'
 
 const inProgressController = {
-  options: {},
+  options: {
+    validate: {
+      query: Joi.object({
+        service: Joi.string().allow(''),
+        teamId: Joi.string().allow(''),
+        kind: Joi.string().allow('')
+      })
+    }
+  },
   handler: async (request, h) => {
-    const repositoriesStatus = await getStatus(request.db, [
-      statuses.inProgress,
-      statuses.failure
-    ])
+    const repositoriesStatus = await getStatus(
+      request.db,
+      [statuses.inProgress, statuses.failure],
+      request.query
+    )
 
     return h.response({ message: 'success', inProgress: repositoriesStatus })
   }

--- a/src/api/status/controllers/index.js
+++ b/src/api/status/controllers/index.js
@@ -1,4 +1,0 @@
-import { inProgressController } from '~/src/api/status/controllers/in-progress.js'
-import { repositoryStatusController } from '~/src/api/status/controllers/repository-status.js'
-
-export { inProgressController, repositoryStatusController }

--- a/src/api/status/helpers/get-status-filters.js
+++ b/src/api/status/helpers/get-status-filters.js
@@ -1,0 +1,47 @@
+import isNil from 'lodash/isNil.js'
+
+/**
+ * @param {import('mongodb').Db} db
+ * @param {string[]} statuses
+ * @param {Record<string, string>} [queryParams]
+ * @returns {Promise<*>}
+ */
+async function getStatusFilters(db, statuses, queryParams = {}) {
+  const kind = queryParams.kind
+
+  const stages = []
+
+  if (!isNil(kind)) {
+    stages.push({
+      $match: { kind }
+    })
+  }
+
+  stages.push(
+    {
+      $match: { status: { $in: statuses } }
+    },
+    {
+      $group: {
+        _id: null,
+        services: { $addToSet: '$repositoryName' },
+        teams: { $addToSet: '$team' }
+      }
+    },
+    {
+      $project: {
+        _id: 0,
+        services: 1,
+        teams: {
+          teamId: 1,
+          name: 1
+        }
+      }
+    }
+  )
+
+  const filters = await db.collection('status').aggregate(stages).toArray()
+  return filters.at(0)
+}
+
+export { getStatusFilters }

--- a/src/api/status/helpers/get-status.js
+++ b/src/api/status/helpers/get-status.js
@@ -1,15 +1,41 @@
+import isNil from 'lodash/isNil.js'
+
 /**
  * Get create service status
  * @param {import('mongodb').Db} db
  * @param {string[]} statuses
+ * @param {Record<string, string>} [queryParams]
  * @returns {Promise<*>}
  */
-async function getStatus(db, statuses) {
+async function getStatus(db, statuses, queryParams = {}) {
+  const service = queryParams.service
+  const teamId = queryParams.teamId
+  const kind = queryParams.kind
   const stages = []
 
   if (statuses?.length) {
     stages.push({
       $match: { status: { $in: statuses } }
+    })
+  }
+
+  if (!isNil(kind)) {
+    stages.push({
+      $match: { kind }
+    })
+  }
+
+  if (!isNil(teamId)) {
+    stages.push({
+      $match: { 'team.teamId': teamId }
+    })
+  }
+
+  if (!isNil(service)) {
+    stages.push({
+      $match: {
+        $or: [{ repositoryName: { $regex: service, $options: 'i' } }]
+      }
     })
   }
 

--- a/src/api/status/index.js
+++ b/src/api/status/index.js
@@ -1,7 +1,6 @@
-import {
-  inProgressController,
-  repositoryStatusController
-} from '~/src/api/status/controllers/index.js'
+import { inProgressController } from '~/src/api/status/controllers/in-progress.js'
+import { repositoryStatusController } from '~/src/api/status/controllers/repository-status.js'
+import { inProgressFiltersController } from '~/src/api/status/controllers/in-progress-filters.js'
 
 const status = {
   plugin: {
@@ -12,6 +11,11 @@ const status = {
           method: 'GET',
           path: '/status/in-progress',
           ...inProgressController
+        },
+        {
+          method: 'GET',
+          path: '/status/in-progress/filters',
+          ...inProgressFiltersController
         },
         {
           method: 'GET',


### PR DESCRIPTION
- Add in progress filters endpoint to provide filters for the service page, for `team` and `service`. For services that have an in-progress or failed creation
- Add query params `service`, `kind` and `teamId` to in-progress endpoint to support providing results for these query params only when filters are used on the services list page