### PR TITLE
Lookup non existant service in decom

### DIFF
--- a/src/api/decommission-service/controller.js
+++ b/src/api/decommission-service/controller.js
@@ -3,7 +3,6 @@ import { removeStatus } from '~/src/api/status/helpers/remove-status.js'
 import { portalBackEndDecommissionService } from '~/src/api/decommission-service/helpers/decommission-portal-backend.js'
 import { triggerRemoveWorkflows } from '~/src/api/decommission-service/helpers/trigger-remove-workflows.js'
 import { getRepositoryInfo } from '~/src/helpers/portal-backend/get-repository-info.js'
-import { undeployServiceFromAllEnvironments } from '~/src/api/undeploy/helpers/undeploy-service-from-all-environments.js'
 import { deleteDockerImages } from '~/src/api/decommission-service/helpers/delete-docker-images.js'
 import { triggerArchiveGithubWorkflow } from '~/src/api/decommission-service/helpers/archive-github-workflow.js'
 import { featureToggles } from '~/src/helpers/feature-toggle/feature-toggles.js'
@@ -39,7 +38,6 @@ const decommissionServiceController = {
 
     const response = await getRepositoryInfo(serviceName)
 
-    await undeployServiceFromAllEnvironments({ serviceName, user, logger })
     await deleteDockerImages(serviceName, user, logger)
     await triggerRemoveWorkflows(serviceName, response.repository, logger)
     await portalBackEndDecommissionService(serviceName)

--- a/src/api/decommission-service/helpers/delete-docker-images.js
+++ b/src/api/decommission-service/helpers/delete-docker-images.js
@@ -1,7 +1,5 @@
 import { deleteDockerHubImages } from '~/src/helpers/remove/workflows/delete-dockerhub-images.js'
 import { deleteEcrImages } from '~/src/helpers/remove/workflows/delete-ecr-images.js'
-import { isFeatureEnabled } from '~/src/helpers/feature-toggle/is-feature-enabled.js'
-import { featureToggles } from '~/src/helpers/feature-toggle/feature-toggles.js'
 
 /**
  * Delete docker images
@@ -13,15 +11,7 @@ import { featureToggles } from '~/src/helpers/feature-toggle/feature-toggles.js'
 export async function deleteDockerImages(serviceName, user, logger) {
   logger.info(`Deleting docker images for service: ${serviceName}`)
 
-  if (isFeatureEnabled(featureToggles.dockerImages.deleteEcr)) {
-    await deleteEcrImages(serviceName, logger)
-  } else {
-    logger.info('Deleting ECR images feature is disabled')
-  }
+  await deleteEcrImages(serviceName, logger)
 
-  if (isFeatureEnabled(featureToggles.dockerImages.deleteDockerHub)) {
-    await deleteDockerHubImages(serviceName, logger)
-  } else {
-    logger.info('Deleting DockerHub images feature is disabled')
-  }
+  await deleteDockerHubImages(serviceName, logger)
 }

--- a/src/api/decommission-service/helpers/delete-docker-images.test.js
+++ b/src/api/decommission-service/helpers/delete-docker-images.test.js
@@ -1,61 +1,23 @@
 import { deleteDockerHubImages } from '~/src/helpers/remove/workflows/delete-dockerhub-images.js'
 import { deleteEcrImages } from '~/src/helpers/remove/workflows/delete-ecr-images.js'
-import { isFeatureEnabled } from '~/src/helpers/feature-toggle/is-feature-enabled.js'
 import { deleteDockerImages } from '~/src/api/decommission-service/helpers/delete-docker-images.js'
 
-jest.mock('~/src/helpers/feature-toggle/is-feature-enabled', () => {
-  return {
-    isFeatureEnabled: jest.fn()
-  }
-})
+jest.mock('~/src/helpers/remove/workflows/delete-dockerhub-images')
+jest.mock('~/src/helpers/remove/workflows/delete-ecr-images')
 
-jest.mock('~/src/helpers/remove/workflows/delete-dockerhub-images', () => {
-  return {
-    deleteDockerHubImages: jest.fn()
-  }
-})
-
-jest.mock('~/src/helpers/remove/workflows/delete-ecr-images', () => {
-  return {
-    deleteEcrImages: jest.fn()
-  }
-})
-
-const logger = {
-  info: jest.fn()
-}
+const logger = { info: jest.fn() }
 const serviceName = 'some-service'
 const user = { id: 'some-user-id', displayName: 'some-name' }
 
 describe('#deleteDockerImages', () => {
-  test('if not enabled should not call delete ECR images', async () => {
-    isFeatureEnabled.mockReturnValue(false)
-
-    await deleteDockerImages(serviceName, user, logger)
-
-    expect(deleteEcrImages).toHaveBeenCalledTimes(0)
-  })
-
-  test('if enabled should call delete ECR images', async () => {
-    isFeatureEnabled.mockReturnValueOnce(true).mockReturnValue(false)
-
+  test('should call delete ECR images', async () => {
     await deleteDockerImages(serviceName, user, logger)
 
     expect(deleteEcrImages).toHaveBeenCalledTimes(1)
     expect(deleteEcrImages).toHaveBeenCalledWith(serviceName, logger)
   })
 
-  test('if not enabled should not call delete DockerHub images', async () => {
-    isFeatureEnabled.mockReturnValue(false)
-
-    await deleteDockerImages(serviceName, user, logger)
-
-    expect(deleteDockerHubImages).toHaveBeenCalledTimes(0)
-  })
-
-  test('if enabled should call delete DockerHub images', async () => {
-    isFeatureEnabled.mockReturnValueOnce(false).mockReturnValue(true)
-
+  test('should call delete DockerHub images', async () => {
     await deleteDockerImages(serviceName, user, logger)
 
     expect(deleteDockerHubImages).toHaveBeenCalledTimes(1)

--- a/src/api/deploy-terminal/controllers/deploy-terminal.js
+++ b/src/api/deploy-terminal/controllers/deploy-terminal.js
@@ -6,7 +6,7 @@ import { sendSnsMessage } from '~/src/helpers/sns/send-sns-message.js'
 import { canRunTerminalInEnvironment } from '~/src/api/deploy-terminal/helpers/can-run-terminal-in-environment.js'
 import { generateTerminalToken } from '~/src/api/deploy-terminal/helpers/generate-terminal-token.js'
 import { deployTerminalPayload } from '~/src/api/deploy-terminal/helpers/deploy-terminal-payload.js'
-import { lookupTenantService } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupTenantService } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 
 const deployTerminalController = {
   options: {

--- a/src/api/deploy/controllers/deploy-service.js
+++ b/src/api/deploy/controllers/deploy-service.js
@@ -7,7 +7,7 @@ import { getRepoTeams } from '~/src/api/deploy/helpers/get-repo-teams.js'
 import { sendSnsDeploymentMessage } from '~/src/api/deploy/helpers/send-sns-deployment-message.js'
 import { generateDeployment } from '~/src/helpers/deployments/generate-deployment.js'
 import { commitDeploymentFile } from '~/src/helpers/deployments/commit-deployment-file.js'
-import { lookupTenantService } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupTenantService } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 import { getLatestAppConfigCommitSha } from '~/src/helpers/portal-backend/get-latest-app-config-commit-sha.js'
 
 const deployFromFileEnvironments = config.get('deployFromFileEnvironments')

--- a/src/api/deploy/controllers/existing-service-info.js
+++ b/src/api/deploy/controllers/existing-service-info.js
@@ -1,5 +1,5 @@
 import { config } from '~/src/config/index.js'
-import { lookupTenantService } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupTenantService } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 import { getExistingDeployment } from '~/src/api/deploy/helpers/get-existing-deployment.js'
 
 const deploymentRepo = config.get('github.repos.appDeployments')

--- a/src/api/undeploy/helpers/delete-deployment-file.js
+++ b/src/api/undeploy/helpers/delete-deployment-file.js
@@ -12,7 +12,10 @@ export async function deleteDeploymentFiles({
 }) {
   logger.info(`Deleting deployment files for ${serviceName}`)
 
-  if (!isFeatureEnabled(featureToggles.undeploy.deleteDeploymentFiles)) {
+  if (
+    !isFeatureEnabled(featureToggles.decommissionService) ||
+    !isFeatureEnabled(featureToggles.undeploy.deleteDeploymentFiles)
+  ) {
     logger.info('Deleting deployment file feature is disabled')
     return
   }

--- a/src/api/undeploy/helpers/delete-deployment-file.test.js
+++ b/src/api/undeploy/helpers/delete-deployment-file.test.js
@@ -21,8 +21,16 @@ describe('#deleteDeploymentFiles', () => {
     expect(removeDeployment).toHaveBeenCalledWith(serviceName, logger)
   })
 
+  test('should not delete deployment file if decommission is disabled', async () => {
+    isFeatureEnabled.mockReturnValueOnce(false).mockReturnValue(true)
+
+    await deleteDeploymentFiles({ serviceName, logger })
+
+    expect(removeDeployment).toHaveBeenCalledTimes(0)
+  })
+
   test('should not delete deployment file if feature disabled', async () => {
-    isFeatureEnabled.mockReturnValue(false)
+    isFeatureEnabled.mockReturnValueOnce(true).mockReturnValue(false)
 
     await deleteDeploymentFiles({ serviceName, logger })
 

--- a/src/api/undeploy/helpers/delete-ecs-service.js
+++ b/src/api/undeploy/helpers/delete-ecs-service.js
@@ -15,7 +15,10 @@ async function deleteEcsService({
 }) {
   logger.info(`Deleting ECS service for ${serviceName} in env ${environment}`)
 
-  if (!isFeatureEnabled(featureToggles.undeploy.deleteEcsService)) {
+  if (
+    !isFeatureEnabled(featureToggles.decommissionService) ||
+    !isFeatureEnabled(featureToggles.undeploy.deleteEcsService)
+  ) {
     logger.info('Deleting ECS service feature is disabled')
     return
   }

--- a/src/api/undeploy/helpers/delete-ecs-service.js
+++ b/src/api/undeploy/helpers/delete-ecs-service.js
@@ -1,6 +1,6 @@
 import { createLogger } from '~/src/helpers/logging/logger.js'
 import { orderedEnvironments } from '~/src/config/environments.js'
-import { lookupTenantService } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupTenantService } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 import { featureToggles } from '~/src/helpers/feature-toggle/feature-toggles.js'
 import { isFeatureEnabled } from '~/src/helpers/feature-toggle/is-feature-enabled.js'
 import { removeEcsService } from '~/src/helpers/remove/workflows/remove-ecs-service.js'

--- a/src/api/undeploy/helpers/delete-ecs-service.test.js
+++ b/src/api/undeploy/helpers/delete-ecs-service.test.js
@@ -2,12 +2,12 @@ import {
   deleteEcsService,
   deleteAllEcsServices
 } from '~/src/api/undeploy/helpers/delete-ecs-service.js'
-import { lookupTenantService } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupTenantService } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 import { isFeatureEnabled } from '~/src/helpers/feature-toggle/is-feature-enabled.js'
 import { removeEcsService } from '~/src/helpers/remove/workflows/remove-ecs-service.js'
 import { featureToggles } from '~/src/helpers/feature-toggle/feature-toggles.js'
 
-jest.mock('~/src/api/deploy/helpers/lookup-tenant-service')
+jest.mock('~/src/helpers/portal-backend/lookup-tenant-service')
 jest.mock('~/src/helpers/feature-toggle/is-feature-enabled')
 jest.mock('~/src/helpers/remove/workflows/remove-ecs-service')
 

--- a/src/api/undeploy/helpers/delete-ecs-service.test.js
+++ b/src/api/undeploy/helpers/delete-ecs-service.test.js
@@ -37,7 +37,37 @@ describe('#deleteEcsService', () => {
     )
   })
 
-  test('should not remove ECS service if feature disabled', async () => {
+  test('should not remove ECS service if decommission is enabled but feature is disabled', async () => {
+    isFeatureEnabled.mockReturnValueOnce(true).mockReturnValue(false)
+
+    await deleteEcsService({ serviceName, environment, logger })
+
+    expect(isFeatureEnabled).toHaveBeenCalledTimes(2)
+    expect(isFeatureEnabled).toHaveBeenNthCalledWith(
+      1,
+      featureToggles.decommissionService
+    )
+    expect(isFeatureEnabled).toHaveBeenLastCalledWith(
+      featureToggles.undeploy.deleteEcsService
+    )
+    expect(lookupTenantService).toHaveBeenCalledTimes(0)
+    expect(removeEcsService).toHaveBeenCalledTimes(0)
+  })
+
+  test('should not remove ECS service if decommission feature is disabled', async () => {
+    isFeatureEnabled.mockReturnValueOnce(false).mockReturnValue(true)
+
+    await deleteEcsService({ serviceName, environment, logger })
+
+    expect(isFeatureEnabled).toHaveBeenCalledTimes(1)
+    expect(isFeatureEnabled).toHaveBeenLastCalledWith(
+      featureToggles.decommissionService
+    )
+    expect(lookupTenantService).toHaveBeenCalledTimes(0)
+    expect(removeEcsService).toHaveBeenCalledTimes(0)
+  })
+
+  test('should not remove ECS service if both features are disabled', async () => {
     isFeatureEnabled.mockReturnValue(false)
 
     await deleteEcsService({ serviceName, environment, logger })

--- a/src/api/undeploy/helpers/scale-ecs-to-zero.js
+++ b/src/api/undeploy/helpers/scale-ecs-to-zero.js
@@ -27,6 +27,11 @@ export async function scaleEcsToZero({
     return
   }
 
+  if (runningDetails.instanceCount === 0) {
+    logger.info('ECS Service already scaled to 0')
+    return
+  }
+
   const deployment = transformRunningDetailsToDeployment(runningDetails, zone)
   const undeployment = scaleDeploymentToZeroInstances({
     deployment,

--- a/src/api/undeploy/helpers/scale-ecs-to-zero.test.js
+++ b/src/api/undeploy/helpers/scale-ecs-to-zero.test.js
@@ -51,6 +51,18 @@ describe('#scaleEcsToZero', () => {
     expect(commitDeploymentFile).toHaveBeenCalledTimes(0)
   })
 
+  test('If existing deployment is already scaled to 0 do nothing', async () => {
+    findRunningDetails.mockReturnValue({
+      ...runningDetails,
+      instanceCount: 0
+    })
+
+    await scaleEcsToZero(scaleDetails)
+
+    expect(findRunningDetails).toHaveBeenCalledTimes(1)
+    expect(commitDeploymentFile).toHaveBeenCalledTimes(0)
+  })
+
   test('With existing deployment should proceed with scale to 0', async () => {
     findRunningDetails.mockReturnValue(runningDetails)
 

--- a/src/api/undeploy/helpers/undeploy-service-from-environment.js
+++ b/src/api/undeploy/helpers/undeploy-service-from-environment.js
@@ -39,31 +39,26 @@ export async function undeployServiceFromEnvironment({
     return
   }
 
-  if (isFeatureEnabled(featureToggles.decommissionService)) {
-    await registerUndeployment(serviceName, environment, user, undeploymentId)
+  await registerUndeployment(serviceName, environment, user, undeploymentId)
 
-    if (isFeatureEnabled(featureToggles.scaleEcsToZero)) {
-      const shouldDeployByFile =
-        deployFromFileEnvironments.includes(environment)
-      if (!shouldDeployByFile) {
-        logger.warn(
-          `Scaling ${serviceName} to zero in ${environment} not possible as env is not file based`
-        )
-      } else {
-        await scaleEcsToZero({
-          serviceName,
-          environment,
-          zone,
-          user,
-          undeploymentId,
-          logger
-        })
-      }
+  if (isFeatureEnabled(featureToggles.scaleEcsToZero)) {
+    const shouldDeployByFile = deployFromFileEnvironments.includes(environment)
+    if (!shouldDeployByFile) {
+      logger.warn(
+        `Scaling ${serviceName} to zero in ${environment} not possible as env is not file based`
+      )
     } else {
-      logger.info('Scale ECS Service to 0 feature is disabled')
+      await scaleEcsToZero({
+        serviceName,
+        environment,
+        zone,
+        user,
+        undeploymentId,
+        logger
+      })
     }
   } else {
-    logger.info('Decommission feature is disabled')
+    logger.info('Scale ECS Service to 0 feature is disabled')
   }
   return undeploymentId
 }

--- a/src/api/undeploy/helpers/undeploy-service-from-environment.js
+++ b/src/api/undeploy/helpers/undeploy-service-from-environment.js
@@ -39,14 +39,9 @@ export async function undeployServiceFromEnvironment({
     return
   }
 
-  if (isFeatureEnabled(featureToggles.undeploy.register)) {
-    await registerUndeployment(serviceName, environment, user, undeploymentId)
-    logger.info('Undeployment registered')
-  } else {
-    logger.info('Undeployment registration feature is disabled')
-  }
+  await registerUndeployment(serviceName, environment, user, undeploymentId)
 
-  if (isFeatureEnabled(featureToggles.undeploy.scaleEcsToZero)) {
+  if (isFeatureEnabled(featureToggles.scaleEcsToZero)) {
     const shouldDeployByFile = deployFromFileEnvironments.includes(environment)
     if (!shouldDeployByFile) {
       logger.warn(

--- a/src/api/undeploy/helpers/undeploy-service-from-environment.js
+++ b/src/api/undeploy/helpers/undeploy-service-from-environment.js
@@ -39,26 +39,31 @@ export async function undeployServiceFromEnvironment({
     return
   }
 
-  await registerUndeployment(serviceName, environment, user, undeploymentId)
+  if (isFeatureEnabled(featureToggles.decommissionService)) {
+    await registerUndeployment(serviceName, environment, user, undeploymentId)
 
-  if (isFeatureEnabled(featureToggles.scaleEcsToZero)) {
-    const shouldDeployByFile = deployFromFileEnvironments.includes(environment)
-    if (!shouldDeployByFile) {
-      logger.warn(
-        `Scaling ${serviceName} to zero in ${environment} not possible as env is not file based`
-      )
+    if (isFeatureEnabled(featureToggles.scaleEcsToZero)) {
+      const shouldDeployByFile =
+        deployFromFileEnvironments.includes(environment)
+      if (!shouldDeployByFile) {
+        logger.warn(
+          `Scaling ${serviceName} to zero in ${environment} not possible as env is not file based`
+        )
+      } else {
+        await scaleEcsToZero({
+          serviceName,
+          environment,
+          zone,
+          user,
+          undeploymentId,
+          logger
+        })
+      }
     } else {
-      await scaleEcsToZero({
-        serviceName,
-        environment,
-        zone,
-        user,
-        undeploymentId,
-        logger
-      })
+      logger.info('Scale ECS Service to 0 feature is disabled')
     }
   } else {
-    logger.info('Scale ECS Service to 0 feature is disabled')
+    logger.info('Decommission feature is disabled')
   }
   return undeploymentId
 }

--- a/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
+++ b/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
@@ -1,6 +1,7 @@
 import { registerUndeployment } from '~/src/api/undeploy/helpers/register-undeployment.js'
 import { scaleEcsToZero } from '~/src/api/undeploy/helpers/scale-ecs-to-zero.js'
 import { lookupServiceInEnvironment } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
+import { featureToggles } from '~/src/helpers/feature-toggle/feature-toggles.js'
 import { isFeatureEnabled } from '~/src/helpers/feature-toggle/is-feature-enabled.js'
 import { getRepositoryInfo } from '~/src/helpers/portal-backend/get-repository-info.js'
 import { undeployServiceFromEnvironment } from '~/src/api/undeploy/helpers/undeploy-service-from-environment.js'
@@ -37,17 +38,7 @@ async function callUndeployServiceFromEnvironment() {
 }
 
 describe('#undeployServiceFromEnvironment', () => {
-  test('if not enabled should not call undeploy registration', async () => {
-    isFeatureEnabled.mockReturnValueOnce(false).mockReturnValue(true)
-
-    await callUndeployServiceFromEnvironment()
-
-    expect(registerUndeployment).toHaveBeenCalledTimes(0)
-  })
-
-  test('if enabled should call undeploy registration', async () => {
-    isFeatureEnabled.mockReturnValue(true)
-
+  test('should register undeployment', async () => {
     await callUndeployServiceFromEnvironment()
 
     expect(registerUndeployment).toHaveBeenCalledTimes(1)
@@ -58,6 +49,7 @@ describe('#undeployServiceFromEnvironment', () => {
 
     await callUndeployServiceFromEnvironment()
 
+    expect(isFeatureEnabled).toHaveBeenCalledWith(featureToggles.scaleEcsToZero)
     expect(scaleEcsToZero).toHaveBeenCalledTimes(0)
   })
 
@@ -66,6 +58,7 @@ describe('#undeployServiceFromEnvironment', () => {
 
     await callUndeployServiceFromEnvironment()
 
+    expect(isFeatureEnabled).toHaveBeenCalledWith(featureToggles.scaleEcsToZero)
     expect(scaleEcsToZero).toHaveBeenCalledTimes(1)
     expect(scaleEcsToZero).toHaveBeenCalledWith({
       serviceName,

--- a/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
+++ b/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
@@ -1,6 +1,6 @@
 import { registerUndeployment } from '~/src/api/undeploy/helpers/register-undeployment.js'
 import { scaleEcsToZero } from '~/src/api/undeploy/helpers/scale-ecs-to-zero.js'
-import { lookupTenantService } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupServiceInEnvironment } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 import { isFeatureEnabled } from '~/src/helpers/feature-toggle/is-feature-enabled.js'
 import { getRepositoryInfo } from '~/src/helpers/portal-backend/get-repository-info.js'
 import { undeployServiceFromEnvironment } from '~/src/api/undeploy/helpers/undeploy-service-from-environment.js'
@@ -8,13 +8,15 @@ import { undeployServiceFromEnvironment } from '~/src/api/undeploy/helpers/undep
 jest.mock('~/src/helpers/feature-toggle/is-feature-enabled')
 jest.mock('~/src/api/undeploy/helpers/register-undeployment')
 jest.mock('~/src/api/undeploy/helpers/scale-ecs-to-zero')
-jest.mock('~/src/api/deploy/helpers/lookup-tenant-service')
+jest.mock('~/src/helpers/portal-backend/lookup-tenant-service')
 jest.mock('~/src/helpers/portal-backend/get-repository-info')
 
 const logger = { info: jest.fn(), warn: jest.fn() }
 registerUndeployment.mockResolvedValue()
 scaleEcsToZero.mockResolvedValue()
-lookupTenantService.mockResolvedValue({ zone: 'some-zone' })
+lookupServiceInEnvironment.mockResolvedValue({
+  serviceJson: { zone: 'some-zone' }
+})
 getRepositoryInfo.mockResolvedValue({ repository: { topics: [] } })
 
 const undeploymentId = crypto.randomUUID()
@@ -83,7 +85,7 @@ describe('#undeployServiceFromEnvironment', () => {
     await callUndeployServiceFromEnvironment()
 
     expect(getRepositoryInfo).toHaveBeenCalledTimes(1)
-    expect(lookupTenantService).toHaveBeenCalledTimes(0)
+    expect(lookupServiceInEnvironment).toHaveBeenCalledTimes(0)
     expect(registerUndeployment).toHaveBeenCalledTimes(0)
     expect(scaleEcsToZero).toHaveBeenCalledTimes(0)
   })

--- a/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
+++ b/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
@@ -47,23 +47,12 @@ describe('#undeployServiceFromEnvironment', () => {
   })
 
   test('if not enabled should not call scaleEcsToZero', async () => {
-    isFeatureEnabled.mockReturnValueOnce(true).mockReturnValue(false)
+    isFeatureEnabled.mockReturnValue(false)
 
     await callUndeployServiceFromEnvironment()
 
     expect(isFeatureEnabled).toHaveBeenLastCalledWith(
       featureToggles.scaleEcsToZero
-    )
-    expect(scaleEcsToZero).toHaveBeenCalledTimes(0)
-  })
-
-  test('if decommission is not enabled should not call scaleEcsToZero', async () => {
-    isFeatureEnabled.mockReturnValueOnce(false).mockReturnValue(true)
-
-    await callUndeployServiceFromEnvironment()
-
-    expect(isFeatureEnabled).toHaveBeenLastCalledWith(
-      featureToggles.decommissionService
     )
     expect(scaleEcsToZero).toHaveBeenCalledTimes(0)
   })

--- a/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
+++ b/src/api/undeploy/helpers/undeploy-service-from-environment.test.js
@@ -39,17 +39,32 @@ async function callUndeployServiceFromEnvironment() {
 
 describe('#undeployServiceFromEnvironment', () => {
   test('should register undeployment', async () => {
+    isFeatureEnabled.mockReturnValue(true)
+
     await callUndeployServiceFromEnvironment()
 
     expect(registerUndeployment).toHaveBeenCalledTimes(1)
   })
 
   test('if not enabled should not call scaleEcsToZero', async () => {
-    isFeatureEnabled.mockReturnValue(false)
+    isFeatureEnabled.mockReturnValueOnce(true).mockReturnValue(false)
 
     await callUndeployServiceFromEnvironment()
 
-    expect(isFeatureEnabled).toHaveBeenCalledWith(featureToggles.scaleEcsToZero)
+    expect(isFeatureEnabled).toHaveBeenLastCalledWith(
+      featureToggles.scaleEcsToZero
+    )
+    expect(scaleEcsToZero).toHaveBeenCalledTimes(0)
+  })
+
+  test('if decommission is not enabled should not call scaleEcsToZero', async () => {
+    isFeatureEnabled.mockReturnValueOnce(false).mockReturnValue(true)
+
+    await callUndeployServiceFromEnvironment()
+
+    expect(isFeatureEnabled).toHaveBeenLastCalledWith(
+      featureToggles.decommissionService
+    )
     expect(scaleEcsToZero).toHaveBeenCalledTimes(0)
   })
 
@@ -59,6 +74,7 @@ describe('#undeployServiceFromEnvironment', () => {
     await callUndeployServiceFromEnvironment()
 
     expect(isFeatureEnabled).toHaveBeenCalledWith(featureToggles.scaleEcsToZero)
+    expect(lookupServiceInEnvironment).toHaveBeenCalledTimes(1)
     expect(scaleEcsToZero).toHaveBeenCalledTimes(1)
     expect(scaleEcsToZero).toHaveBeenCalledWith({
       serviceName,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -482,13 +482,13 @@ const config = convict({
     decommissionService: {
       doc: 'Feature flag for decommission service',
       format: Boolean,
-      default: false,
+      default: true,
       env: 'FEATURE_DECOMMISSION_SERVICE'
     },
     scaleEcsToZero: {
       doc: 'Feature flag for scaling ECS instances to 0',
       format: Boolean,
-      default: false,
+      default: true,
       env: 'FEATURE_SCALE_ECS_TO_0'
     },
     undeploy: {
@@ -509,26 +509,26 @@ const config = convict({
       deleteEcr: {
         doc: 'Feature flag for deleting ECR images',
         format: Boolean,
-        default: false,
+        default: true,
         env: 'FEATURE_DELETE_ECR_IMAGES'
       },
       deleteDockerHub: {
         doc: 'Feature flag for deleting DockerHub images',
         format: Boolean,
-        default: false,
+        default: true,
         env: 'FEATURE_DELETE_DOCKERHUB_IMAGES'
       }
     },
     removeServiceWorkflows: {
       doc: 'Feature flag for removing a service workflows',
       format: Boolean,
-      default: false,
+      default: true,
       env: 'FEATURE_REMOVE_SERVICE_WORKFLOWS'
     },
     archiveGitHubWorkflow: {
       doc: 'Feature flag for archiving github repo on decommission',
       format: Boolean,
-      default: false,
+      default: true,
       env: 'FEATURE_ARCHIVE_GITHUB_WORKFLOW'
     }
   }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -479,6 +479,18 @@ const config = convict({
     env: 'ENABLE_SECURE_CONTEXT'
   },
   features: {
+    decommissionService: {
+      doc: 'Feature flag for decommission service',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_DECOMMISSION_SERVICE'
+    },
+    scaleEcsToZero: {
+      doc: 'Feature flag for scaling ECS instances to 0',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_SCALE_ECS_TO_0'
+    },
     undeploy: {
       deleteDeploymentFiles: {
         doc: 'Feature flag for deleting deployment files',
@@ -491,18 +503,6 @@ const config = convict({
         format: Boolean,
         default: false,
         env: 'FEATURE_DELETE_ECS_SERVICE'
-      },
-      register: {
-        doc: 'Feature flag for register undeploy',
-        format: Boolean,
-        default: false,
-        env: 'FEATURE_UNDEPLOY_REGISTER'
-      },
-      scaleEcsToZero: {
-        doc: 'Feature flag for scaling ECS instances to 0',
-        format: Boolean,
-        default: false,
-        env: 'FEATURE_SCALE_ECS_TO_0'
       }
     },
     dockerImages: {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -505,20 +505,6 @@ const config = convict({
         env: 'FEATURE_DELETE_ECS_SERVICE'
       }
     },
-    dockerImages: {
-      deleteEcr: {
-        doc: 'Feature flag for deleting ECR images',
-        format: Boolean,
-        default: true,
-        env: 'FEATURE_DELETE_ECR_IMAGES'
-      },
-      deleteDockerHub: {
-        doc: 'Feature flag for deleting DockerHub images',
-        format: Boolean,
-        default: true,
-        env: 'FEATURE_DELETE_DOCKERHUB_IMAGES'
-      }
-    },
     removeServiceWorkflows: {
       doc: 'Feature flag for removing a service workflows',
       format: Boolean,

--- a/src/helpers/feature-toggle/feature-toggles.js
+++ b/src/helpers/feature-toggle/feature-toggles.js
@@ -1,10 +1,6 @@
 export const featureToggles = {
   decommissionService: 'decommissionService',
   archiveGitHubWorkflow: 'archiveGitHubWorkflow',
-  dockerImages: {
-    deleteEcr: 'dockerImages.deleteEcr',
-    deleteDockerHub: 'dockerImages.deleteDockerHub'
-  },
   removeServiceWorkflows: 'removeServiceWorkflows',
   scaleEcsToZero: 'scaleEcsToZero',
   undeploy: {

--- a/src/helpers/feature-toggle/feature-toggles.js
+++ b/src/helpers/feature-toggle/feature-toggles.js
@@ -1,14 +1,14 @@
 export const featureToggles = {
+  decommissionService: 'decommissionService',
   archiveGitHubWorkflow: 'archiveGitHubWorkflow',
   dockerImages: {
     deleteEcr: 'dockerImages.deleteEcr',
     deleteDockerHub: 'dockerImages.deleteDockerHub'
   },
   removeServiceWorkflows: 'removeServiceWorkflows',
+  scaleEcsToZero: 'scaleEcsToZero',
   undeploy: {
     deleteDeploymentFiles: 'undeploy.deleteDeploymentFiles',
-    deleteEcsService: 'undeploy.deleteEcsService',
-    register: 'undeploy.register',
-    scaleEcsToZero: 'undeploy.scaleEcsToZero'
+    deleteEcsService: 'undeploy.deleteEcsService'
   }
 }

--- a/src/helpers/portal-backend/lookup-tenant-service.js
+++ b/src/helpers/portal-backend/lookup-tenant-service.js
@@ -53,18 +53,37 @@ async function lookupTenantServiceFromGitHub(
  * @returns {Promise<undefined|*>}
  */
 async function lookupTenantService(service, environment, logger) {
+  const { response, serviceJson } = await lookupServiceInEnvironment(
+    service,
+    environment
+  )
+  if (response.ok) {
+    return serviceJson
+  }
+  logger.error(`Service lookup failed: ${serviceJson.message}`)
+  throw Boom.boomify(new Error(serviceJson.message), {
+    statusCode: response.status
+  })
+}
+
+/**
+ * Get service from portal-backend
+ * @param {string} service
+ * @param {string} environment
+ * @returns {Promise<undefined|*>}
+ */
+async function lookupServiceInEnvironment(service, environment) {
   const url = `${config.get('portalBackendUrl')}/tenant-services/${service}/${environment}`
   const response = await fetcher(url, {
     method: 'get',
     headers: { 'Content-Type': 'application/json' }
   })
-  const json = await response.json()
-
-  if (response.ok) {
-    return json
-  }
-  logger.error(`Service lookup failed: ${json.message}`)
-  throw Boom.boomify(new Error(json.message), { statusCode: response.status })
+  const serviceJson = await response.json()
+  return { response, serviceJson }
 }
 
-export { lookupTenantService, lookupTenantServiceFromGitHub }
+export {
+  lookupServiceInEnvironment,
+  lookupTenantService,
+  lookupTenantServiceFromGitHub
+}

--- a/src/listeners/github/helpers/bulk-update-tf-svc-infra.js
+++ b/src/listeners/github/helpers/bulk-update-tf-svc-infra.js
@@ -6,7 +6,7 @@ import {
 import { updateOverallStatus } from '~/src/helpers/create/init-creation-status.js'
 import { createPlaceholderArtifact } from '~/src/listeners/github/helpers/create-placeholder-artifact.js'
 import { createLogger } from '~/src/helpers/logging/logger.js'
-import { lookupTenantServiceFromGitHub } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupTenantServiceFromGitHub } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 
 /**
  * given a list of services, update the tf-svc-infra status for all of them to success

--- a/src/listeners/github/helpers/bulk-update-tf-svc-infra.test.js
+++ b/src/listeners/github/helpers/bulk-update-tf-svc-infra.test.js
@@ -5,7 +5,7 @@ import {
 } from '~/src/listeners/github/status-repo.js'
 
 import { createPlaceholderArtifact } from '~/src/listeners/github/helpers/create-placeholder-artifact.js'
-import { lookupTenantServiceFromGitHub } from '~/src/api/deploy/helpers/lookup-tenant-service.js'
+import { lookupTenantServiceFromGitHub } from '~/src/helpers/portal-backend/lookup-tenant-service.js'
 import { updateOverallStatus } from '~/src/helpers/create/init-creation-status.js'
 import { statuses } from '~/src/constants/statuses.js'
 
@@ -17,7 +17,7 @@ jest.mock('~/src/listeners/github/helpers/create-placeholder-artifact', () => ({
   createPlaceholderArtifact: jest.fn()
 }))
 
-jest.mock('~/src/api/deploy/helpers/lookup-tenant-service', () => ({
+jest.mock('~/src/helpers/portal-backend/lookup-tenant-service', () => ({
   lookupTenantServiceFromGitHub: jest.fn()
 }))
 


### PR DESCRIPTION
Currently blows up (boom) if looking up a service in a env it has not been set up in.
This changes to just ignore that env.

In addition tweaking feature flags. Removing  unnecessary ones that are now stable.
And defaulting to true for most decom ones.