### PR TITLE
changes env_files to environment_files

### DIFF
--- a/src/api/deploy-test-suite/helpers/generate-test-run-message.js
+++ b/src/api/deploy-test-suite/helpers/generate-test-run-message.js
@@ -30,7 +30,7 @@ const testRunMessageValidation = Joi.object({
     BASE_URL: Joi.string().required(),
     ENVIRONMENT: environmentValidation
   }).unknown(true),
-  env_files: Joi.array()
+  environment_files: Joi.array()
     .items(
       Joi.object({
         value: Joi.string().required(),
@@ -48,7 +48,7 @@ const testRunMessageValidation = Joi.object({
  * @param {string} runId
  * @param {{id:string, displayName: string}} user
  * @param {string} configCommitSha
- * @returns {{cluster_name: string, image, desired_count: number, webdriver_sidecar: {browser: string, version: string}, image_version: string, env_files: [{type: string, value: string},{type: string, value: string},{type: string, value: string},{type: string, value: string}], environment_variables: {ENVIRONMENT, BASE_URL: string, HTTP_PROXY: never}, environment, zone: string, port: number, name, task_memory: number, runId, deployed_by: {displayName, userId}, task_cpu: number}}
+ * @returns {{cluster_name: string, image, desired_count: number, webdriver_sidecar: {browser: string, version: string}, image_version: string, environment_files: [{type: string, value: string},{type: string, value: string},{type: string, value: string},{type: string, value: string}], environment_variables: {ENVIRONMENT, BASE_URL: string, HTTP_PROXY: never}, environment, zone: string, port: number, name, task_memory: number, runId, deployed_by: {displayName, userId}, task_cpu: number}}
  */
 const generateTestRunMessage = (
   imageName,
@@ -86,7 +86,7 @@ const generateTestRunMessage = (
       ENVIRONMENT: environment,
       HTTP_PROXY: config.get('httpProxy') // Once we support cdp-app-config in test suites this can go
     },
-    env_files: [
+    environment_files: [
       {
         value: `${basePath}/global/global_fixed.env`,
         type: 's3'

--- a/src/api/deploy-test-suite/helpers/run-test-suite.test.js
+++ b/src/api/deploy-test-suite/helpers/run-test-suite.test.js
@@ -63,7 +63,7 @@ describe('#runTestSuite', () => {
           BASE_URL: `https://test.cdp-int.defra.cloud/`,
           ENVIRONMENT: 'test'
         }),
-        env_files: [
+        environment_files: [
           {
             value: `${basePath}/global/global_fixed.env`,
             type: 's3'


### PR DESCRIPTION
The deployment lambda has some odd special case handling/hack for env_files which doesn't play well with the test runner lambda.

I've updated the test runner lambda template to just loop over the environment_files and add them one at a time rather than try and inject them as a whole block.

See: https://github.com/DEFRA/cdp-ecs-deployment-lambda/blob/main/lib/ecs_deploy.py#L391-L393