### PR TITLE
519032 - Uses version instead of latest in testrun

### DIFF
--- a/src/api/deploy-test-suite/helpers/generate-test-run-message.js
+++ b/src/api/deploy-test-suite/helpers/generate-test-run-message.js
@@ -5,7 +5,8 @@ import {
   memoryValidation,
   repositoryNameValidation,
   runIdValidation,
-  userWithUserIdValidation
+  userWithUserIdValidation,
+  versionValidation
 } from '~/src/api/helpers/schema/common-validations.js'
 import Joi from 'joi'
 
@@ -17,7 +18,7 @@ const testRunMessageValidation = Joi.object({
   cluster_name: Joi.string().equal('ecs-public'),
   name: repositoryNameValidation,
   image: repositoryNameValidation,
-  image_version: Joi.string().pattern(/\d+\.\d+\.\d+/),
+  image_version: versionValidation,
   port: Joi.number().integer().equal(80).required(),
   task_cpu: cpuValidation,
   task_memory: memoryValidation,

--- a/src/api/deploy-test-suite/helpers/generate-test-run-message.js
+++ b/src/api/deploy-test-suite/helpers/generate-test-run-message.js
@@ -17,7 +17,7 @@ const testRunMessageValidation = Joi.object({
   cluster_name: Joi.string().equal('ecs-public'),
   name: repositoryNameValidation,
   image: repositoryNameValidation,
-  image_version: Joi.number().equal('latest'),
+  image_version: Joi.string().pattern(/\d+\.\d+\.\d+/),
   port: Joi.number().integer().equal(80).required(),
   task_cpu: cpuValidation,
   task_memory: memoryValidation,
@@ -44,6 +44,7 @@ const testRunMessageValidation = Joi.object({
 /**
  *
  * @param {string} imageName
+ * @param {string} tag
  * @param {string} environment
  * @param {string} runId
  * @param {{id:string, displayName: string}} user
@@ -52,6 +53,7 @@ const testRunMessageValidation = Joi.object({
  */
 const generateTestRunMessage = (
   imageName,
+  tag,
   environment,
   runId,
   user,
@@ -69,7 +71,7 @@ const generateTestRunMessage = (
     cluster_name: 'ecs-public',
     name: imageName,
     image: imageName,
-    image_version: 'latest',
+    image_version: tag,
     port: 80,
     task_cpu: 4096,
     task_memory: 8192,

--- a/src/api/deploy-test-suite/helpers/generate-test-run-message.test.js
+++ b/src/api/deploy-test-suite/helpers/generate-test-run-message.test.js
@@ -7,6 +7,7 @@ describe('#generateTestRunMessage', () => {
     config.get = jest.fn().mockReturnValue('http://fake-proxy')
     const message = generateTestRunMessage(
       'some-service',
+      '123.44.111',
       'infra-dev',
       crypto.randomUUID(),
       {
@@ -17,5 +18,6 @@ describe('#generateTestRunMessage', () => {
     )
 
     expect(message.deployed_by.userId).toBe('some-id')
+    expect(message.image_version).toBe('123.44.111')
   })
 })

--- a/src/api/deploy-test-suite/helpers/record-test-run.js
+++ b/src/api/deploy-test-suite/helpers/record-test-run.js
@@ -8,13 +8,13 @@ import {
   environmentValidation,
   repositoryNameValidation,
   runIdValidation,
-  tagValidation,
+  versionValidation,
   userWithIdValidation
 } from '~/src/api/helpers/schema/common-validations.js'
 
 const recordTestRunValidation = Joi.object({
   testSuite: repositoryNameValidation,
-  tag: tagValidation,
+  tag: versionValidation,
   runId: runIdValidation,
   environment: environmentValidation,
   user: userWithIdValidation,

--- a/src/api/deploy-test-suite/helpers/record-test-run.js
+++ b/src/api/deploy-test-suite/helpers/record-test-run.js
@@ -8,19 +8,32 @@ import {
   environmentValidation,
   repositoryNameValidation,
   runIdValidation,
+  tagValidation,
   userWithIdValidation
 } from '~/src/api/helpers/schema/common-validations.js'
 
 const recordTestRunValidation = Joi.object({
   testSuite: repositoryNameValidation,
+  tag: tagValidation,
   runId: runIdValidation,
   environment: environmentValidation,
   user: userWithIdValidation,
   configVersion: commitShaValidation
 })
 
+/**
+ *
+ * @param {string} imageName
+ * @param {string} tag
+ * @param {string} runId
+ * @param {string} environment
+ * @param {{ id: string, displayName: string}} user
+ * @param {string} configCommitSha
+ * @returns {Promise<{Response}|Response>}
+ */
 async function recordTestRun(
   imageName,
+  tag,
   runId,
   environment,
   user,
@@ -35,6 +48,7 @@ async function recordTestRun(
   )
   const body = {
     testSuite: imageName,
+    tag,
     runId,
     environment,
     user,

--- a/src/api/deploy-test-suite/helpers/record-test-run.test.js
+++ b/src/api/deploy-test-suite/helpers/record-test-run.test.js
@@ -12,6 +12,7 @@ describe('#recordTestRun', () => {
 
     const res = await recordTestRun(
       'some-service',
+      '1.1.0',
       randomUUID(),
       'test',
       {

--- a/src/api/deploy-test-suite/helpers/run-test-suite.js
+++ b/src/api/deploy-test-suite/helpers/run-test-suite.js
@@ -5,6 +5,7 @@ import { generateTestRunMessage } from '~/src/api/deploy-test-suite/helpers/gene
 import { sendSnsMessage } from '~/src/helpers/sns/send-sns-message.js'
 import { recordTestRun } from '~/src/api/deploy-test-suite/helpers/record-test-run.js'
 import { getLatestAppConfigCommitSha } from '~/src/helpers/portal-backend/get-latest-app-config-commit-sha.js'
+import { getLatestImage } from '~/src/helpers/portal-backend/get-latest-image.js'
 
 const snsRunTestTopic = config.get('snsRunTestTopicArn')
 
@@ -24,8 +25,11 @@ async function runTestSuite(imageName, environment, user, snsClient, logger) {
 
   logger.info(`Config commit sha ${configLatestCommitSha}`)
 
+  const tag = (await getLatestImage(imageName))?.tag
+
   const runMessage = generateTestRunMessage(
     imageName,
+    tag,
     environment,
     runId,
     user,
@@ -49,6 +53,7 @@ async function runTestSuite(imageName, environment, user, snsClient, logger) {
   // Inform the backend about the new test run so it can track the results.
   await recordTestRun(
     imageName,
+    tag,
     runId,
     environment,
     user,

--- a/src/api/deploy-test-suite/helpers/run-test-suite.test.js
+++ b/src/api/deploy-test-suite/helpers/run-test-suite.test.js
@@ -11,6 +11,10 @@ jest.mock(
   })
 )
 
+jest.mock('~/src/helpers/portal-backend/get-latest-image.js', () => ({
+  getLatestImage: jest.fn().mockResolvedValue({ tag: '1.0.0' })
+}))
+
 jest.mock('~/src/helpers/sns/send-sns-message.js', () => ({
   sendSnsMessage: jest.fn().mockResolvedValue({})
 }))
@@ -47,7 +51,7 @@ describe('#runTestSuite', () => {
         zone: 'public',
         name: 'some-service',
         image: 'some-service',
-        image_version: 'latest',
+        image_version: '1.0.0',
         port: 80,
         task_cpu: 4096,
         task_memory: 8192,

--- a/src/api/helpers/schema/common-validations.js
+++ b/src/api/helpers/schema/common-validations.js
@@ -65,6 +65,8 @@ const repositoryNameValidation = Joi.string()
     'string.max': '32 characters or less'
   })
 
+const tagValidation = Joi.string().required()
+
 export {
   commitShaValidation,
   cpuValidation,
@@ -76,6 +78,7 @@ export {
   memoryValidation,
   repositoryNameValidation,
   runIdValidation,
+  tagValidation,
   userWithIdValidation,
   userWithUserIdValidation,
   versionValidation,

--- a/src/api/helpers/schema/common-validations.js
+++ b/src/api/helpers/schema/common-validations.js
@@ -65,8 +65,6 @@ const repositoryNameValidation = Joi.string()
     'string.max': '32 characters or less'
   })
 
-const tagValidation = Joi.string().required()
-
 export {
   commitShaValidation,
   cpuValidation,
@@ -78,7 +76,6 @@ export {
   memoryValidation,
   repositoryNameValidation,
   runIdValidation,
-  tagValidation,
   userWithIdValidation,
   userWithUserIdValidation,
   versionValidation,

--- a/src/helpers/portal-backend/get-latest-image.js
+++ b/src/helpers/portal-backend/get-latest-image.js
@@ -1,0 +1,30 @@
+import Boom from '@hapi/boom'
+
+import { config } from '~/src/config/index.js'
+import { fetcher } from '~/src/helpers/fetcher.js'
+
+/**
+ * Gets test run details from cdp-portal-backend.
+ * @typedef {object} Artifact
+ * @property {string} created
+ * @property {string} tag
+ * @property {string} sha256
+ * @property {string} serviceName
+ * @property {{}} annotations
+ */
+
+/**
+ * @param {string} serviceName
+ * @returns {Promise<Artifact>}
+ */
+async function getLatestImage(serviceName) {
+  const url =
+    config.get('portalBackendUrl') + `/artifacts/${serviceName}/latest`
+  const response = await fetcher(url, { method: 'get' })
+  if (response.ok) {
+    return await response.json()
+  }
+  throw Boom.notFound(`No images found for ${serviceName}`)
+}
+
+export { getLatestImage }


### PR DESCRIPTION
Looks up the actual test version before running the test suite. Test version is passed to PBE and recorded during creation rather than on the first message.

This allows us towards using immutable tags in ECR.