### PR TITLE
CORE-1279 uses repository from template on service creation

### DIFF
--- a/src/helpers/create/create-microservice.js
+++ b/src/helpers/create/create-microservice.js
@@ -47,7 +47,7 @@ async function createMicroservice({
       team.github,
       topics,
       {
-        serviceTypeTemplate: template.id,
+        serviceTypeTemplate: template.repositoryName,
         templateTag
       }
     ),

--- a/src/helpers/create/create-microservice.test.js
+++ b/src/helpers/create/create-microservice.test.js
@@ -163,4 +163,44 @@ describe('#create-test-runner-suite', () => {
       logger
     )
   })
+
+  test('Should create minimal backend from the right repository', async () => {
+    const teamId = randomUUID()
+    fetchTeam.mockResolvedValue({
+      teamId,
+      name: 'test',
+      github: 'test',
+      serviceCodes: ['TST']
+    })
+
+    const userId = randomUUID()
+    await createMicroservice({
+      logger,
+      repositoryName,
+      template: microserviceTemplates['cdp-node-backend-template-minimal'],
+      templateTag: 'minimal',
+      teamId,
+      user: {
+        id: userId,
+        displayName: 'test user'
+      }
+    })
+
+    // Create repo
+    const createRepoInputs = {
+      serviceTypeTemplate: 'cdp-node-backend-template',
+      repositoryName,
+      team: 'test',
+      additionalGitHubTopics: 'cdp,service,node,backend',
+      templateTag: 'minimal'
+    }
+    expect(triggerWorkflow).toHaveBeenCalledWith(
+      config.get('github.org'),
+      config.get('github.repos.createWorkflows'),
+      'create_microservice.yml',
+      createRepoInputs,
+      repositoryName,
+      logger
+    )
+  })
 })


### PR DESCRIPTION
Related to https://github.com/DEFRA/cdp-portal-frontend/pull/1013
ssops has been updated to use the repository name from the template data rather than the id (which is often, but not always the same value)