### PR TITLE
CORE-3281 pass subtype to remove-service workflow so that we can conditionally execute actions if they are a frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,9 +2319,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,9 +2336,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2359,9 +2353,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2379,9 +2370,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2399,9 +2387,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2419,9 +2404,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6617,9 +6599,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6641,9 +6620,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6665,9 +6641,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6689,9 +6662,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8898,9 +8868,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/api/decommission-service/helpers/trigger-remove-workflow.js
+++ b/src/api/decommission-service/helpers/trigger-remove-workflow.js
@@ -7,7 +7,12 @@ import { triggerRemoveTenantWorkflow } from '../../../helpers/remove/workflows/t
  */
 async function triggerRemoveWorkflow(entity, logger) {
   logger.info(`Triggering remove workflow for: ${entity.name}`)
-  await triggerRemoveTenantWorkflow(entity.name, entity.type, logger)
+  await triggerRemoveTenantWorkflow(
+    entity.name,
+    entity.type,
+    entity.subType,
+    logger
+  )
 }
 
 export { triggerRemoveWorkflow }

--- a/src/api/decommission-service/helpers/trigger-remove-workflow.test.js
+++ b/src/api/decommission-service/helpers/trigger-remove-workflow.test.js
@@ -39,6 +39,7 @@ describe('#triggerRemoveWorkflow', () => {
     expect(triggerRemoveTenantWorkflow).toHaveBeenCalledWith(
       serviceName,
       'Microservice',
+      'Backend',
       logger
     )
   })
@@ -52,6 +53,7 @@ describe('#triggerRemoveWorkflow', () => {
     expect(triggerRemoveTenantWorkflow).toHaveBeenCalledWith(
       serviceName,
       'Microservice',
+      'Frontend',
       logger
     )
   })
@@ -65,6 +67,7 @@ describe('#triggerRemoveWorkflow', () => {
     expect(triggerRemoveTenantWorkflow).toHaveBeenCalledWith(
       serviceName,
       'TestSuite',
+      'Journey',
       logger
     )
   })

--- a/src/helpers/remove/workflows/trigger-remove-tenant-workflow.js
+++ b/src/helpers/remove/workflows/trigger-remove-tenant-workflow.js
@@ -7,14 +7,15 @@ import { config } from '#config/config.js'
  * @param {import("pino").Logger} logger
  * @returns {Promise<void>}
  */
-async function triggerRemoveTenantWorkflow(name, type, logger) {
+async function triggerRemoveTenantWorkflow(name, type, subtype, logger) {
   const org = config.get('github.org')
   const repo = config.get('github.repos.cdpTenantConfig')
   const workflowId = config.get('workflows.removeTenantService')
 
   const inputs = {
     service: name,
-    type
+    type,
+    subtype
   }
 
   await triggerWorkflow(org, repo, workflowId, inputs, name, logger)

--- a/src/helpers/remove/workflows/trigger-remove-tenant-workflow.test.js
+++ b/src/helpers/remove/workflows/trigger-remove-tenant-workflow.test.js
@@ -15,10 +15,11 @@ describe('#triggerRemoveTenantWorkflow', () => {
 
     const serviceName = 'my-service-name'
     const type = 'Microservice'
+    const subtype = 'Frontend'
 
     triggerWorkflow.mockReturnValue({})
 
-    await triggerRemoveTenantWorkflow(serviceName, type, logger)
+    await triggerRemoveTenantWorkflow(serviceName, type, subtype, logger)
 
     expect(triggerWorkflow).toHaveBeenCalledWith(
       'DEFRA',
@@ -26,7 +27,8 @@ describe('#triggerRemoveTenantWorkflow', () => {
       'remove-service.yml',
       {
         service: serviceName,
-        type
+        type,
+        subtype
       },
       serviceName,
       logger


### PR DESCRIPTION
When we run the remove-service workflow we want to be able to execute different workflows depending on whether the service is a frontend or backend (e.g. `cdp-app-shuttering` should only run for frontends)