### PR TITLE
CORE-3424: Enable prod deployment for canary prod

### DIFF
--- a/src/api/deploy/helpers/can-auto-deploy-to-prod.js
+++ b/src/api/deploy/helpers/can-auto-deploy-to-prod.js
@@ -1,0 +1,12 @@
+const scheduledDeployUserId = '00000000-0000-0000-0000-00000000001'
+const canaryServiceName = 'cdp-canary-deployment-backend'
+
+function canAutoDeployToProd({ imageName, environment, user }) {
+  if (environment !== 'prod') {
+    return true
+  }
+
+  return user?.id === scheduledDeployUserId && imageName === canaryServiceName
+}
+
+export { canAutoDeployToProd, scheduledDeployUserId, canaryServiceName }

--- a/src/api/deploy/helpers/can-auto-deploy.js
+++ b/src/api/deploy/helpers/can-auto-deploy.js
@@ -1,7 +1,7 @@
 const scheduledDeployUserId = '00000000-0000-0000-0000-00000000001'
 const canaryServiceName = 'cdp-canary-deployment-backend'
 
-function canAutoDeployToProd({ imageName, environment, user }) {
+function canAutoDeploy({ imageName, environment, user }) {
   if (environment !== 'prod') {
     return true
   }
@@ -9,4 +9,4 @@ function canAutoDeployToProd({ imageName, environment, user }) {
   return user?.id === scheduledDeployUserId && imageName === canaryServiceName
 }
 
-export { canAutoDeployToProd, scheduledDeployUserId, canaryServiceName }
+export { canAutoDeploy, scheduledDeployUserId, canaryServiceName }

--- a/src/api/deploy/helpers/schema/auto-deploy-service-validation.js
+++ b/src/api/deploy/helpers/schema/auto-deploy-service-validation.js
@@ -9,7 +9,7 @@ import {
   userWithIdValidation,
   versionValidation
 } from '@defra/cdp-validation-kit'
-import { canAutoDeployToProd } from '../can-auto-deploy-to-prod.js'
+import { canAutoDeploy } from '../can-auto-deploy.js'
 
 const autoDeployServiceValidation = Joi.object({
   imageName: repositoryNameValidation,
@@ -21,7 +21,7 @@ const autoDeployServiceValidation = Joi.object({
   memory: memoryValidation,
   configVersion: commitShaValidation
 }).custom((payload, helpers) => {
-  if (canAutoDeployToProd(payload)) {
+  if (canAutoDeploy(payload)) {
     return payload
   }
 

--- a/src/api/deploy/helpers/schema/auto-deploy-service-validation.js
+++ b/src/api/deploy/helpers/schema/auto-deploy-service-validation.js
@@ -2,23 +2,32 @@ import Joi from 'joi'
 import {
   commitShaValidation,
   cpuValidation,
-  environmentExceptForProdValidation,
+  environmentValidation,
   instanceCountValidation,
   memoryValidation,
   repositoryNameValidation,
   userWithIdValidation,
   versionValidation
 } from '@defra/cdp-validation-kit'
+import { canAutoDeployToProd } from '../can-auto-deploy-to-prod.js'
 
 const autoDeployServiceValidation = Joi.object({
   imageName: repositoryNameValidation,
   version: versionValidation,
-  environment: environmentExceptForProdValidation,
+  environment: environmentValidation,
   user: userWithIdValidation,
   instanceCount: instanceCountValidation,
   cpu: cpuValidation,
   memory: memoryValidation,
   configVersion: commitShaValidation
+}).custom((payload, helpers) => {
+  if (canAutoDeployToProd(payload)) {
+    return payload
+  }
+
+  return helpers.message(
+    '"environment" must be one of [infra-dev, management, dev, test, perf-test, ext-test]'
+  )
 })
 
 export { autoDeployServiceValidation }

--- a/src/api/deploy/helpers/schema/auto-deploy-service-validation.test.js
+++ b/src/api/deploy/helpers/schema/auto-deploy-service-validation.test.js
@@ -50,12 +50,10 @@ describe('#autoDeployServiceValidation', () => {
 
     expect(
       autoDeployServiceValidation.validate(payload).error.details.at(0).message
-    ).toContain(
-      '"environment" must be one of [infra-dev, management, dev, test, perf-test, ext-test]'
-    )
+    ).toContain('"environment" must be one of [')
   })
 
-  test("Schema shouldn't allow prod environment", () => {
+  test("Schema shouldn't allow prod environment for auto-deployment user", () => {
     const payload = {
       imageName: 'cdp-portal-frontend',
       environment: 'prod',
@@ -75,6 +73,48 @@ describe('#autoDeployServiceValidation', () => {
     ).toContain(
       '"environment" must be one of [infra-dev, management, dev, test, perf-test, ext-test]'
     )
+  })
+
+  test("Schema shouldn't allow prod environment for scheduled user on non-canary service", () => {
+    const payload = {
+      imageName: 'cdp-portal-frontend',
+      environment: 'prod',
+      version: '1.0.0',
+      instanceCount: 4,
+      cpu: 1024,
+      memory: 2048,
+      user: {
+        id: '00000000-0000-0000-0000-00000000001',
+        displayName: 'Auto schedule'
+      },
+      configVersion: 'abc123def'
+    }
+
+    expect(
+      autoDeployServiceValidation.validate(payload).error.details.at(0).message
+    ).toContain(
+      '"environment" must be one of [infra-dev, management, dev, test, perf-test, ext-test]'
+    )
+  })
+
+  test('Schema should allow prod environment for scheduled canary deployment', () => {
+    const payload = {
+      imageName: 'cdp-canary-deployment-backend',
+      environment: 'prod',
+      version: '1.0.0',
+      instanceCount: 4,
+      cpu: 1024,
+      memory: 2048,
+      user: {
+        id: '00000000-0000-0000-0000-00000000001',
+        displayName: 'Auto schedule'
+      },
+      configVersion: 'abc123def'
+    }
+
+    expect(autoDeployServiceValidation.validate(payload)).toEqual({
+      value: payload
+    })
   })
 
   test('Schema should fail validation with expected version error', () => {


### PR DESCRIPTION
I we want to have daily deployment on ALL envs including prod, we need to allow it here. 

I'm being defensive here and only allow it for 'cdp-canary-deployment-backend'