### PR TITLE
CORE-3293: Route shuttering to SNS for new shuttering via monolambda

### DIFF
--- a/src/api/shutter/controllers/shutter-service.js
+++ b/src/api/shutter/controllers/shutter-service.js
@@ -30,10 +30,10 @@ const shutterServiceController = {
     }
   },
   handler: async (request, h) => {
-    const { payload, auth, logger } = request
+    const { payload, auth, logger, snsClient } = request
     const user = await getScopedUser(payload.serviceName, auth, logger)
 
-    await shutterServiceWorkflow(payload, user, logger)
+    await shutterServiceWorkflow(payload, user, logger, snsClient)
 
     return h.response().code(statusCodes.ok)
   }

--- a/src/api/shutter/controllers/unshutter-service.js
+++ b/src/api/shutter/controllers/unshutter-service.js
@@ -30,10 +30,10 @@ const unshutterServiceController = {
     }
   },
   handler: async (request, h) => {
-    const { payload, auth, logger } = request
+    const { payload, auth, logger, snsClient } = request
     const user = await getScopedUser(payload.serviceName, auth, logger)
 
-    await unshutterServiceWorkflow(payload, user, logger)
+    await unshutterServiceWorkflow(payload, user, logger, snsClient)
 
     return h.response().code(statusCodes.ok)
   }

--- a/src/api/shutter/helpers/should-use-shutter-v2.js
+++ b/src/api/shutter/helpers/should-use-shutter-v2.js
@@ -1,0 +1,11 @@
+import { config } from '#config/config.js'
+
+/**
+ * Temporary, remove when shutter v2 is fully enabled
+ * @param {string} env
+ * @returns {boolean}
+ */
+export function shouldUseShutterV2(env) {
+  const allowedEnvs = config.get('shutterV2Environments').split(',')
+  return (allowedEnvs ?? []).includes(env)
+}

--- a/src/api/shutter/helpers/should-use-shutter-v2.test.js
+++ b/src/api/shutter/helpers/should-use-shutter-v2.test.js
@@ -1,0 +1,21 @@
+const get = vi.fn()
+
+vi.mock('#config/config.js', () => ({
+  config: { get }
+}))
+
+describe('#shouldUseShutterV2', () => {
+  test('returns true when environment is enabled', async () => {
+    get.mockReturnValue('infra-dev,test')
+    const { shouldUseShutterV2 } = await import('./should-use-shutter-v2.js')
+
+    expect(shouldUseShutterV2('infra-dev')).toBe(true)
+  })
+
+  test('returns false when environment is not enabled', async () => {
+    get.mockReturnValue('infra-dev,test')
+    const { shouldUseShutterV2 } = await import('./should-use-shutter-v2.js')
+
+    expect(shouldUseShutterV2('prod')).toBe(false)
+  })
+})

--- a/src/api/shutter/helpers/shutter-service-workflow.js
+++ b/src/api/shutter/helpers/shutter-service-workflow.js
@@ -1,6 +1,9 @@
 import { config } from '#config/config.js'
 import { triggerWorkflow } from '../../../helpers/github/trigger-workflow.js'
 import { registerShuttering } from './register-shuttering.js'
+import { sendSnsMessage } from '../../../helpers/sns/send-sns-message.js'
+import { shouldUseShutterV2 } from './should-use-shutter-v2.js'
+import { shutterUrlType } from '../../../constants/waf.js'
 
 const buildWorkFlowInputs = (inputs) => ({
   service_name: inputs.serviceName,
@@ -9,36 +12,93 @@ const buildWorkFlowInputs = (inputs) => ({
   url_type: inputs.urlType
 })
 
-async function shutterServiceWorkflow(inputs, user, logger) {
+const INTERNAL_DOMAIN_SUFFIX = '.cdp-int.defra.cloud'
+
+function resolveManageShutteringRouting({ urlType, url }) {
+  const isInternal = url.endsWith(INTERNAL_DOMAIN_SUFFIX)
+
+  if (urlType === shutterUrlType.frontendVanityUrl) {
+    return {
+      shutterType: 'www',
+      webAclName: isInternal
+        ? 'cdp-platform-acl-public-internal'
+        : 'cdp-platform-acl-public-external'
+    }
+  }
+
+  return {
+    shutterType: 'api',
+    webAclName: isInternal
+      ? 'cdp-platform-api-acl-private'
+      : 'cdp-platform-api-acl-public'
+  }
+}
+
+async function publishManageShutteringEvent(inputs, action, snsClient, logger) {
+  const topic = config.get('monoLambdaTriggerTopicArn')
+  const { shutterType, webAclName } = resolveManageShutteringRouting(inputs)
+
+  const event = {
+    event_type: 'manage_shuttering',
+    timestamp: new Date().toISOString(),
+    payload: {
+      action,
+      fqdn: inputs.url,
+      service_name: inputs.serviceName,
+      shutter_type: shutterType,
+      web_acl_name: webAclName
+    }
+  }
+
+  await sendSnsMessage(
+    snsClient,
+    topic,
+    event,
+    logger,
+    inputs.environment,
+    undefined,
+    inputs.url
+  )
+}
+
+async function shutterServiceWorkflow(inputs, user, logger, snsClient) {
   const org = config.get('github.org')
   const repo = config.get('github.repos.cdpTenantConfig')
   const workflow = config.get('workflows.addShutterWorkflow')
 
-  await triggerWorkflow(
-    org,
-    repo,
-    workflow,
-    buildWorkFlowInputs(inputs),
-    inputs.url,
-    logger
-  )
+  if (shouldUseShutterV2(inputs.environment)) {
+    await publishManageShutteringEvent(inputs, 'shutter', snsClient, logger)
+  } else {
+    await triggerWorkflow(
+      org,
+      repo,
+      workflow,
+      buildWorkFlowInputs(inputs),
+      inputs.url,
+      logger
+    )
+  }
 
   await registerShuttering({ ...inputs, shuttered: true, actionedBy: user })
 }
 
-async function unshutterServiceWorkflow(inputs, user, logger) {
+async function unshutterServiceWorkflow(inputs, user, logger, snsClient) {
   const org = config.get('github.org')
   const repo = config.get('github.repos.cdpTenantConfig')
   const workflow = config.get('workflows.removeShutterWorkflow')
 
-  await triggerWorkflow(
-    org,
-    repo,
-    workflow,
-    buildWorkFlowInputs(inputs),
-    inputs.url,
-    logger
-  )
+  if (shouldUseShutterV2(inputs.environment)) {
+    await publishManageShutteringEvent(inputs, 'unshutter', snsClient, logger)
+  } else {
+    await triggerWorkflow(
+      org,
+      repo,
+      workflow,
+      buildWorkFlowInputs(inputs),
+      inputs.url,
+      logger
+    )
+  }
 
   await registerShuttering({ ...inputs, shuttered: false, actionedBy: user })
 }

--- a/src/api/shutter/helpers/shutter-service-workflow.test.js
+++ b/src/api/shutter/helpers/shutter-service-workflow.test.js
@@ -1,0 +1,261 @@
+import { shutterUrlType } from '../../../constants/waf.js'
+
+const get = vi.fn()
+const triggerWorkflow = vi.fn()
+const registerShuttering = vi.fn()
+const sendSnsMessage = vi.fn()
+
+vi.mock('#config/config.js', () => ({
+  config: { get }
+}))
+vi.mock('../../../helpers/github/trigger-workflow.js', () => ({
+  triggerWorkflow
+}))
+vi.mock('./register-shuttering.js', () => ({
+  registerShuttering
+}))
+vi.mock('../../../helpers/sns/send-sns-message.js', () => ({
+  sendSnsMessage
+}))
+
+const topicArn = 'arn:aws:sns:eu-west-2:000000000000:mono-lambda-trigger-topic'
+
+const configValues = (shutterV2Environments) => (key) =>
+  ({
+    shutterV2Environments,
+    monoLambdaTriggerTopicArn: topicArn,
+    'github.org': 'DEFRA',
+    'github.repos.cdpTenantConfig': 'cdp-tenant-config',
+    'workflows.addShutterWorkflow': 'create-shuttering.yml',
+    'workflows.removeShutterWorkflow': 'remove-shuttering.yml'
+  })[key]
+
+const user = { id: 'some-user-id', displayName: 'Some User' }
+const logger = { debug: vi.fn(), info: vi.fn() }
+const snsClient = { send: vi.fn() }
+
+const buildInputs = (overrides = {}) => ({
+  serviceName: 'cdp-portal-frontend',
+  environment: 'infra-dev',
+  url: 'portal-test.cdp-int.defra.cloud',
+  urlType: shutterUrlType.frontendVanityUrl,
+  ...overrides
+})
+
+const publishedEvent = () => sendSnsMessage.mock.calls[0][2]
+
+describe('#shutterServiceWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when shutter v2 is enabled for the environment', () => {
+    beforeEach(() => {
+      get.mockImplementation(configValues('infra-dev'))
+    })
+
+    describe('web ACL and shutter type routing', () => {
+      test.each([
+        [
+          'frontend vanity url on internal domain',
+          shutterUrlType.frontendVanityUrl,
+          'portal-test.cdp-int.defra.cloud',
+          'www',
+          'cdp-platform-acl-public-internal'
+        ],
+        [
+          'frontend vanity url on external domain',
+          shutterUrlType.frontendVanityUrl,
+          'portal.defra.gov.uk',
+          'www',
+          'cdp-platform-acl-public-external'
+        ],
+        [
+          'api gateway vanity url on internal domain',
+          shutterUrlType.apigwVanityUrl,
+          'some-service.api.infra-dev.cdp-int.defra.cloud',
+          'api',
+          'cdp-platform-api-acl-private'
+        ],
+        [
+          'api gateway vanity url on external domain',
+          shutterUrlType.apigwVanityUrl,
+          'some-service.api.defra.gov.uk',
+          'api',
+          'cdp-platform-api-acl-public'
+        ]
+      ])(
+        'routes %s to the expected ACL',
+        async (_description, urlType, url, expectedShutterType, expectedAcl) => {
+          const { shutterServiceWorkflow } = await import(
+            './shutter-service-workflow.js'
+          )
+          const inputs = buildInputs({ urlType, url })
+
+          await shutterServiceWorkflow(inputs, user, logger, snsClient)
+
+          expect(publishedEvent().payload).toEqual({
+            action: 'shutter',
+            fqdn: url,
+            service_name: inputs.serviceName,
+            shutter_type: expectedShutterType,
+            web_acl_name: expectedAcl
+          })
+        }
+      )
+    })
+
+    test('publishes a manage_shuttering event with MessageGroupId set to the fqdn', async () => {
+      const { shutterServiceWorkflow } = await import(
+        './shutter-service-workflow.js'
+      )
+      const inputs = buildInputs()
+
+      await shutterServiceWorkflow(inputs, user, logger, snsClient)
+
+      expect(sendSnsMessage).toHaveBeenCalledWith(
+        snsClient,
+        topicArn,
+        expect.objectContaining({
+          event_type: 'manage_shuttering',
+          timestamp: expect.any(String)
+        }),
+        logger,
+        inputs.environment,
+        undefined,
+        inputs.url
+      )
+      expect(triggerWorkflow).not.toHaveBeenCalled()
+    })
+
+    test('registers shuttering as shuttered', async () => {
+      const { shutterServiceWorkflow } = await import(
+        './shutter-service-workflow.js'
+      )
+      const inputs = buildInputs()
+
+      await shutterServiceWorkflow(inputs, user, logger, snsClient)
+
+      expect(registerShuttering).toHaveBeenCalledWith({
+        ...inputs,
+        shuttered: true,
+        actionedBy: user
+      })
+    })
+  })
+
+  describe('when shutter v2 is not enabled for the environment', () => {
+    beforeEach(() => {
+      get.mockImplementation(configValues(''))
+    })
+
+    test('triggers the github workflow and does not publish to sns', async () => {
+      const { shutterServiceWorkflow } = await import(
+        './shutter-service-workflow.js'
+      )
+      const inputs = buildInputs()
+
+      await shutterServiceWorkflow(inputs, user, logger, snsClient)
+
+      expect(triggerWorkflow).toHaveBeenCalledWith(
+        'DEFRA',
+        'cdp-tenant-config',
+        'create-shuttering.yml',
+        {
+          service_name: inputs.serviceName,
+          environment: inputs.environment,
+          url: inputs.url,
+          url_type: inputs.urlType
+        },
+        inputs.url,
+        logger
+      )
+      expect(sendSnsMessage).not.toHaveBeenCalled()
+      expect(registerShuttering).toHaveBeenCalledWith({
+        ...inputs,
+        shuttered: true,
+        actionedBy: user
+      })
+    })
+  })
+})
+
+describe('#unshutterServiceWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when shutter v2 is enabled for the environment', () => {
+    beforeEach(() => {
+      get.mockImplementation(configValues('infra-dev'))
+    })
+
+    test('publishes an unshutter manage_shuttering event', async () => {
+      const { unshutterServiceWorkflow } = await import(
+        './shutter-service-workflow.js'
+      )
+      const inputs = buildInputs()
+
+      await unshutterServiceWorkflow(inputs, user, logger, snsClient)
+
+      expect(publishedEvent().payload).toEqual({
+        action: 'unshutter',
+        fqdn: inputs.url,
+        service_name: inputs.serviceName,
+        shutter_type: 'www',
+        web_acl_name: 'cdp-platform-acl-public-internal'
+      })
+      expect(triggerWorkflow).not.toHaveBeenCalled()
+    })
+
+    test('registers shuttering as not shuttered', async () => {
+      const { unshutterServiceWorkflow } = await import(
+        './shutter-service-workflow.js'
+      )
+      const inputs = buildInputs()
+
+      await unshutterServiceWorkflow(inputs, user, logger, snsClient)
+
+      expect(registerShuttering).toHaveBeenCalledWith({
+        ...inputs,
+        shuttered: false,
+        actionedBy: user
+      })
+    })
+  })
+
+  describe('when shutter v2 is not enabled for the environment', () => {
+    beforeEach(() => {
+      get.mockImplementation(configValues(''))
+    })
+
+    test('triggers the github remove workflow and does not publish to sns', async () => {
+      const { unshutterServiceWorkflow } = await import(
+        './shutter-service-workflow.js'
+      )
+      const inputs = buildInputs()
+
+      await unshutterServiceWorkflow(inputs, user, logger, snsClient)
+
+      expect(triggerWorkflow).toHaveBeenCalledWith(
+        'DEFRA',
+        'cdp-tenant-config',
+        'remove-shuttering.yml',
+        {
+          service_name: inputs.serviceName,
+          environment: inputs.environment,
+          url: inputs.url,
+          url_type: inputs.urlType
+        },
+        inputs.url,
+        logger
+      )
+      expect(sendSnsMessage).not.toHaveBeenCalled()
+      expect(registerShuttering).toHaveBeenCalledWith({
+        ...inputs,
+        shuttered: false,
+        actionedBy: user
+      })
+    })
+  })
+})

--- a/src/api/shutter/helpers/shutter-service-workflow.test.js
+++ b/src/api/shutter/helpers/shutter-service-workflow.test.js
@@ -86,10 +86,15 @@ describe('#shutterServiceWorkflow', () => {
         ]
       ])(
         'routes %s to the expected ACL',
-        async (_description, urlType, url, expectedShutterType, expectedAcl) => {
-          const { shutterServiceWorkflow } = await import(
-            './shutter-service-workflow.js'
-          )
+        async (
+          _description,
+          urlType,
+          url,
+          expectedShutterType,
+          expectedAcl
+        ) => {
+          const { shutterServiceWorkflow } =
+            await import('./shutter-service-workflow.js')
           const inputs = buildInputs({ urlType, url })
 
           await shutterServiceWorkflow(inputs, user, logger, snsClient)
@@ -106,9 +111,8 @@ describe('#shutterServiceWorkflow', () => {
     })
 
     test('publishes a manage_shuttering event with MessageGroupId set to the fqdn', async () => {
-      const { shutterServiceWorkflow } = await import(
-        './shutter-service-workflow.js'
-      )
+      const { shutterServiceWorkflow } =
+        await import('./shutter-service-workflow.js')
       const inputs = buildInputs()
 
       await shutterServiceWorkflow(inputs, user, logger, snsClient)
@@ -129,9 +133,8 @@ describe('#shutterServiceWorkflow', () => {
     })
 
     test('registers shuttering as shuttered', async () => {
-      const { shutterServiceWorkflow } = await import(
-        './shutter-service-workflow.js'
-      )
+      const { shutterServiceWorkflow } =
+        await import('./shutter-service-workflow.js')
       const inputs = buildInputs()
 
       await shutterServiceWorkflow(inputs, user, logger, snsClient)
@@ -150,9 +153,8 @@ describe('#shutterServiceWorkflow', () => {
     })
 
     test('triggers the github workflow and does not publish to sns', async () => {
-      const { shutterServiceWorkflow } = await import(
-        './shutter-service-workflow.js'
-      )
+      const { shutterServiceWorkflow } =
+        await import('./shutter-service-workflow.js')
       const inputs = buildInputs()
 
       await shutterServiceWorkflow(inputs, user, logger, snsClient)
@@ -191,9 +193,8 @@ describe('#unshutterServiceWorkflow', () => {
     })
 
     test('publishes an unshutter manage_shuttering event', async () => {
-      const { unshutterServiceWorkflow } = await import(
-        './shutter-service-workflow.js'
-      )
+      const { unshutterServiceWorkflow } =
+        await import('./shutter-service-workflow.js')
       const inputs = buildInputs()
 
       await unshutterServiceWorkflow(inputs, user, logger, snsClient)
@@ -209,9 +210,8 @@ describe('#unshutterServiceWorkflow', () => {
     })
 
     test('registers shuttering as not shuttered', async () => {
-      const { unshutterServiceWorkflow } = await import(
-        './shutter-service-workflow.js'
-      )
+      const { unshutterServiceWorkflow } =
+        await import('./shutter-service-workflow.js')
       const inputs = buildInputs()
 
       await unshutterServiceWorkflow(inputs, user, logger, snsClient)
@@ -230,9 +230,8 @@ describe('#unshutterServiceWorkflow', () => {
     })
 
     test('triggers the github remove workflow and does not publish to sns', async () => {
-      const { unshutterServiceWorkflow } = await import(
-        './shutter-service-workflow.js'
-      )
+      const { unshutterServiceWorkflow } =
+        await import('./shutter-service-workflow.js')
       const inputs = buildInputs()
 
       await unshutterServiceWorkflow(inputs, user, logger, snsClient)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -148,6 +148,12 @@ const config = convict({
     default: '',
     env: 'DIRECT_DEPLOYMENTS'
   },
+  shutterV2Environments: {
+    doc: 'Enable shutter v2 (manage_shuttering via mono-lambda) for specific environments (comma separated)',
+    format: String,
+    default: '',
+    env: 'SHUTTER_V2_ENVIRONMENTS'
+  },
   mongo: {
     mongoUrl: {
       doc: 'URL for mongodb',

--- a/src/helpers/sns/send-sns-message.js
+++ b/src/helpers/sns/send-sns-message.js
@@ -7,7 +7,8 @@ async function sendSnsMessage(
   message,
   logger,
   environment = message?.environment,
-  deduplicationId = crypto.randomUUID()
+  deduplicationId = crypto.randomUUID(),
+  messageGroupId = environment
 ) {
   const input = {
     TopicArn: topic,
@@ -24,7 +25,7 @@ async function sendSnsMessage(
   // queue. Luckily, AWS requires all fifo queues to end with `.fifo` so we can selectively add these params.
   if (topic.endsWith('fifo')) {
     input.MessageDeduplicationId = deduplicationId
-    input.MessageGroupId = environment
+    input.MessageGroupId = messageGroupId
   }
 
   const command = new PublishCommand(input)


### PR DESCRIPTION
- Add SHUTTER_V2_ENVIRONMENTS flag and shouldUseShutterV2() helper
- Publish SNS manage_shuttering events when flag is enabled for the environment
- Keep GitHub workflow path unchanged when flag is off