### PR TITLE
CORE-3293: Clean up unused fields after centralizing ACL

### DIFF
--- a/src/api/shutter/helpers/shutter-service-workflow.js
+++ b/src/api/shutter/helpers/shutter-service-workflow.js
@@ -3,7 +3,6 @@ import { triggerWorkflow } from '../../../helpers/github/trigger-workflow.js'
 import { registerShuttering } from './register-shuttering.js'
 import { sendSnsMessage } from '../../../helpers/sns/send-sns-message.js'
 import { shouldUseShutterV2 } from './should-use-shutter-v2.js'
-import { shutterUrlType } from '../../../constants/waf.js'
 
 const buildWorkFlowInputs = (inputs) => ({
   service_name: inputs.serviceName,
@@ -12,31 +11,8 @@ const buildWorkFlowInputs = (inputs) => ({
   url_type: inputs.urlType
 })
 
-const INTERNAL_DOMAIN_SUFFIX = '.cdp-int.defra.cloud'
-
-function resolveManageShutteringRouting({ urlType, url }) {
-  const isInternal = url.endsWith(INTERNAL_DOMAIN_SUFFIX)
-
-  if (urlType === shutterUrlType.frontendVanityUrl) {
-    return {
-      shutterType: 'www',
-      webAclName: isInternal
-        ? 'cdp-platform-acl-public-internal'
-        : 'cdp-platform-acl-public-external'
-    }
-  }
-
-  return {
-    shutterType: 'api',
-    webAclName: isInternal
-      ? 'cdp-platform-api-acl-private'
-      : 'cdp-platform-api-acl-public'
-  }
-}
-
 async function publishManageShutteringEvent(inputs, action, snsClient, logger) {
   const topic = config.get('monoLambdaTriggerTopicArn')
-  const { shutterType, webAclName } = resolveManageShutteringRouting(inputs)
 
   const event = {
     event_type: 'manage_shuttering',
@@ -45,8 +21,7 @@ async function publishManageShutteringEvent(inputs, action, snsClient, logger) {
       action,
       fqdn: inputs.url,
       service_name: inputs.serviceName,
-      shutter_type: shutterType,
-      web_acl_name: webAclName
+      url_type: inputs.urlType
     }
   }
 

--- a/src/api/shutter/helpers/shutter-service-workflow.js
+++ b/src/api/shutter/helpers/shutter-service-workflow.js
@@ -20,8 +20,7 @@ async function publishManageShutteringEvent(inputs, action, snsClient, logger) {
     payload: {
       action,
       fqdn: inputs.url,
-      service_name: inputs.serviceName,
-      url_type: inputs.urlType
+      service_name: inputs.serviceName
     }
   }
 

--- a/src/api/shutter/helpers/shutter-service-workflow.test.js
+++ b/src/api/shutter/helpers/shutter-service-workflow.test.js
@@ -54,60 +54,22 @@ describe('#shutterServiceWorkflow', () => {
       get.mockImplementation(configValues('infra-dev'))
     })
 
-    describe('web ACL and shutter type routing', () => {
-      test.each([
-        [
-          'frontend vanity url on internal domain',
-          shutterUrlType.frontendVanityUrl,
-          'portal-test.cdp-int.defra.cloud',
-          'www',
-          'cdp-platform-acl-public-internal'
-        ],
-        [
-          'frontend vanity url on external domain',
-          shutterUrlType.frontendVanityUrl,
-          'portal.defra.gov.uk',
-          'www',
-          'cdp-platform-acl-public-external'
-        ],
-        [
-          'api gateway vanity url on internal domain',
-          shutterUrlType.apigwVanityUrl,
-          'some-service.api.infra-dev.cdp-int.defra.cloud',
-          'api',
-          'cdp-platform-api-acl-private'
-        ],
-        [
-          'api gateway vanity url on external domain',
-          shutterUrlType.apigwVanityUrl,
-          'some-service.api.defra.gov.uk',
-          'api',
-          'cdp-platform-api-acl-public'
-        ]
-      ])(
-        'routes %s to the expected ACL',
-        async (
-          _description,
-          urlType,
-          url,
-          expectedShutterType,
-          expectedAcl
-        ) => {
-          const { shutterServiceWorkflow } =
-            await import('./shutter-service-workflow.js')
-          const inputs = buildInputs({ urlType, url })
+    test('publishes a slim payload for shutter requests', async () => {
+      const { shutterServiceWorkflow } =
+        await import('./shutter-service-workflow.js')
+      const inputs = buildInputs({
+        urlType: shutterUrlType.apigwVanityUrl,
+        url: 'some-service.api.defra.gov.uk'
+      })
 
-          await shutterServiceWorkflow(inputs, user, logger, snsClient)
+      await shutterServiceWorkflow(inputs, user, logger, snsClient)
 
-          expect(publishedEvent().payload).toEqual({
-            action: 'shutter',
-            fqdn: url,
-            service_name: inputs.serviceName,
-            shutter_type: expectedShutterType,
-            web_acl_name: expectedAcl
-          })
-        }
-      )
+      expect(publishedEvent().payload).toEqual({
+        action: 'shutter',
+        fqdn: inputs.url,
+        service_name: inputs.serviceName,
+        url_type: inputs.urlType
+      })
     })
 
     test('publishes a manage_shuttering event with MessageGroupId set to the fqdn', async () => {
@@ -203,8 +165,7 @@ describe('#unshutterServiceWorkflow', () => {
         action: 'unshutter',
         fqdn: inputs.url,
         service_name: inputs.serviceName,
-        shutter_type: 'www',
-        web_acl_name: 'cdp-platform-acl-public-internal'
+        url_type: inputs.urlType
       })
       expect(triggerWorkflow).not.toHaveBeenCalled()
     })

--- a/src/api/shutter/helpers/shutter-service-workflow.test.js
+++ b/src/api/shutter/helpers/shutter-service-workflow.test.js
@@ -67,8 +67,7 @@ describe('#shutterServiceWorkflow', () => {
       expect(publishedEvent().payload).toEqual({
         action: 'shutter',
         fqdn: inputs.url,
-        service_name: inputs.serviceName,
-        url_type: inputs.urlType
+        service_name: inputs.serviceName
       })
     })
 
@@ -164,8 +163,7 @@ describe('#unshutterServiceWorkflow', () => {
       expect(publishedEvent().payload).toEqual({
         action: 'unshutter',
         fqdn: inputs.url,
-        service_name: inputs.serviceName,
-        url_type: inputs.urlType
+        service_name: inputs.serviceName
       })
       expect(triggerWorkflow).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
- Removed SSO-side ACL routing (resolveManageShutteringRouting)
- Shutter v2 SNS payload now sends only action, fqdn, service_name, url_type
- Mono-lambda resolves ACL from platform state; v1 GitHub workflow path unchanged
- Updated tests for the slim payload